### PR TITLE
 hot fix to attribute

### DIFF
--- a/src/pugihtml.cpp
+++ b/src/pugihtml.cpp
@@ -2098,7 +2098,23 @@ namespace
 										}
 										else THROW_ERROR(status_bad_attribute, s);
 									}
-									else THROW_ERROR(status_bad_attribute, s);
+                                    else {//hot fix:try to fix that attribute=value situation;
+                                        ch='"';
+                                        a->value=s;
+                                        char_t* dp=s;
+                                        char_t temp;
+                                        const char *sch="> /";
+                                        //find the end of attribute,200 length is enough,it must return a position;
+                                        dp=std::find_first_of(s,s+200,sch,sch+2);
+                                        temp=*dp;//backup the former char
+                                        *dp='"';//hack at the end position;
+                                        s=strconv_attribute(s,ch);
+                                        *dp=temp;//restore it;
+                                        s--;// back it because we come to the " but it is > indeed;
+                                        if (IS_CHARTYPE(*s, ct_start_symbol)) THROW_ERROR(status_bad_attribute, s);
+
+                                    }
+                                    //THROW_ERROR(status_bad_attribute, s);
 								}
 								else if (*s == '/')
 								{


### PR DESCRIPTION
hello.
i just write a hot fix to recognise attribute.
like that attribute=value;
eg color=#FFFFF
i meet this situation.so i need to fix it.

the method is that
first 
let ch=' " ';
then change the char of end of the attribute to ' " ' temply;
then use function strconv_attribute to recognise attribute.
finally let the char of end of the attribute back to before.

really a small fix.
i test it works good. though i fear some wrong i dont know.
so please chech again.

code around pugihtml.cpp:2101.

ps.your pugihtml is excellent. 
